### PR TITLE
fix banner image

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
     "dist": "docs/assets/js/"
   },
   "images": {
-    "src": "src/images/**/*.{gif,jpg,jpeg,JPG,JPEG,png,svg}",
+    "src": "src/images/**/*.{gif,jpg,jpeg,JPG,JPEG,png,PNG,svg}",
     "dest": "public/assets/images/",
     "dist": "docs/assets/images/"
   },

--- a/src/html/partials/header.html
+++ b/src/html/partials/header.html
@@ -2,7 +2,7 @@
 
   <h1 class="title">Buscador de Series</h1>
   <div class="logo">
-    <img src="./assets/images/tvshowstimer2-desktop.png" alt="logo Series Searcher">
+    <img src="./assets/images/tvshowstimer2-desktop.PNG" alt="logo Series Searcher">
   </div>
 
 


### PR DESCRIPTION
Another option is to rename images so every extension is in lowercase and there's no `.PNG`